### PR TITLE
setup.cfg: update «license» field

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ author = pohmelie
 author_email = multisosnooley@gmail.com
 description = Simple asynchronous dependency injector for python
 long_description = file: readme.md
-license = file: license.txt
+license = WTFPL
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3


### PR DESCRIPTION
Now installation fails with
```
pip install ainject
Collecting ainject
  Downloading ainject-0.0.2.tar.gz (3.2 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-vvec_nwb/ainject_46f75261649e4186bdac44f85965a8f5/setup.py", line 4, in <module>
          config = setuptools.config.read_configuration("setup.cfg")
        File "/home/vasily566/PycharmProjects/SslService/env/lib/python3.10/site-packages/setuptools/config.py", line 95, in read_configuration
          handlers = parse_configuration(
        File "/home/vasily566/PycharmProjects/SslService/env/lib/python3.10/site-packages/setuptools/config.py", line 158, in parse_configuration
          meta.parse()
        File "/home/vasily566/PycharmProjects/SslService/env/lib/python3.10/site-packages/setuptools/config.py", line 498, in parse
          section_parser_method(section_options)
        File "/home/vasily566/PycharmProjects/SslService/env/lib/python3.10/site-packages/setuptools/config.py", line 469, in parse_section
          self[name] = value
        File "/home/vasily566/PycharmProjects/SslService/env/lib/python3.10/site-packages/setuptools/config.py", line 222, in __setitem__
          value = parser(value)
        File "/home/vasily566/PycharmProjects/SslService/env/lib/python3.10/site-packages/setuptools/config.py", line 332, in parser
          raise ValueError(
      ValueError: Only strings are accepted for the license field, files are not accepted
      [end of output]

```